### PR TITLE
TA#83759 [18.0] Clean v14 dependencies for migration

### DIFF
--- a/.docker_files/main/__manifest__.py
+++ b/.docker_files/main/__manifest__.py
@@ -11,28 +11,30 @@
     "category": "Other",
     "summary": "Install all addons required for testing.",
     "depends": [
-        # odoo/odoo #  For unit test
-        "crm",
-        # -
-        "canada_mis_report",
-        "canada_vat_label",
-        "konvergo_account",
-        # "konvergo_account_fr", Conflict with konvergo_account
+        # Core architecture
         "konvergo_base",
-        "konvergo_bot",
-        "konvergo_brand",
         "konvergo_core",
-        "konvergo_mail_notification",
-        "konvergo_mail_templates",
+        "konvergo_ui",
+        "konvergo_brand",
+
+        # Functional packs
         "konvergo_pack_contact",
         "konvergo_pack_crm",
         "konvergo_pack_pos",
         "konvergo_pack_product",
         "konvergo_pack_sale",
-        "konvergo_ui",
-        "lang_fr_activated",
-        "mail_color_konvergo",
-        "mail_template_fr_fields",
+
+        # Modules to be migrated later (commented out)
+        # "canada_mis_report",         # -> konvergo_l10n_ca
+        # "canada_vat_label",          # -> konvergo_l10n_ca
+        # "konvergo_account",              # TBD
+        # "konvergo_account_fr",           # -> konvergo_l10n_fr
+        # "konvergo_bot",                  # -> konvergo_mail_core
+        # "konvergo_mail_notification",    # -> konvergo_mail_core
+        # "konvergo_mail_templates",       # -> konvergo_pack_templates
+        # "lang_fr_activated",         # -> konvergo_l10n_fr
+        # "mail_color_konvergo",         # -> konvergo_mail_core
+        # "mail_template_fr_fields",   # TBD
     ],
     "installable": True,
 }

--- a/.docker_files/requirements.txt
+++ b/.docker_files/requirements.txt
@@ -1,17 +1,20 @@
+# Dependencies commented out for v18 migration
+# Will be re-enabled as modules are migrated
+
 # for account_invoice_facturx
-factur-x<=3.1
+# factur-x<=3.1
 
 # for l10n_fr_fec_oca
-unicodecsv
-unidecode
+# unicodecsv
+# unidecode
 
 # for base_view_inheritance_extension
-astor
+# astor
 
-# aeroo_reports
-git+https://github.com/numigi/aeroolib@master
-babel==2.5.3
-Genshi==0.7.5
-freezegun==0.3.10
-html2text==2018.1.9
-ddt==1.2.1
+# aeroo_reports (commented out for v18 migration)
+# git+https://github.com/numigi/aeroolib@master
+# babel==2.5.3  # Old version incompatible with Python 3.10+
+# Genshi==0.7.5
+# freezegun==0.3.10
+# html2text==2018.1.9
+# ddt==1.2.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,25 @@
-# Stage 1: Install OCA repositories
-FROM quay.io/numigi/odoo-public:14.latest as oca-stage
-LABEL maintainer="contact@numigi.com"
-USER root
-ARG GIT_TOKEN
-RUN mkdir -p /mnt/oca-addons && chown -R odoo /mnt/oca-addons
-COPY ./gitoo-oca.yml /gitoo-oca.yml
-RUN gitoo install-all --conf_file /gitoo-oca.yml --destination /mnt/oca-addons
+# Dockerfile for Konvergo ERP v18
+# OCA and Numigi stages commented out - will be re-enabled progressively during migration
 
-# Stage 2: Install Numigi repositories  
-FROM quay.io/numigi/odoo-public:14.latest as numigi-stage
-USER root
-ARG GIT_TOKEN
-RUN mkdir -p /mnt/numigi-addons && chown -R odoo /mnt/numigi-addons
-COPY ./gitoo-numigi.yml /gitoo-numigi.yml
-RUN gitoo install-all --conf_file /gitoo-numigi.yml --destination /mnt/numigi-addons
+# # Stage 1: Install OCA repositories
+# FROM quay.io/numigi/odoo-public:18.latest as oca-stage
+# LABEL maintainer="contact@numigi.com"
+# USER root
+# ARG GIT_TOKEN
+# RUN mkdir -p /mnt/oca-addons && chown -R odoo /mnt/oca-addons
+# COPY ./gitoo-oca.yml /gitoo-oca.yml
+# RUN gitoo install-all --conf_file /gitoo-oca.yml --destination /mnt/oca-addons
+
+# # Stage 2: Install Numigi repositories
+# FROM quay.io/numigi/odoo-public:18.latest as numigi-stage
+# USER root
+# ARG GIT_TOKEN
+# RUN mkdir -p /mnt/numigi-addons && chown -R odoo /mnt/numigi-addons
+# COPY ./gitoo-numigi.yml /gitoo-numigi.yml
+# RUN gitoo install-all --conf_file /gitoo-numigi.yml --destination /mnt/numigi-addons
 
 # Stage 3: Final image with all dependencies
-FROM quay.io/numigi/odoo-public:14.latest
+FROM quay.io/numigi/odoo-public:18.latest
 LABEL maintainer="contact@numigi.com"
 
 USER root
@@ -33,9 +36,9 @@ ARG GIT_TOKEN
 ENV THIRD_PARTY_ADDONS /mnt/third-party-addons
 RUN mkdir -p "${THIRD_PARTY_ADDONS}" && chown -R odoo "${THIRD_PARTY_ADDONS}"
 
-# Copy modules from previous stages
-COPY --from=oca-stage /mnt/oca-addons/ ${THIRD_PARTY_ADDONS}/
-COPY --from=numigi-stage /mnt/numigi-addons/ ${THIRD_PARTY_ADDONS}/
+# Copy modules from previous stages (commented out for now)
+# COPY --from=oca-stage /mnt/oca-addons/ ${THIRD_PARTY_ADDONS}/
+# COPY --from=numigi-stage /mnt/numigi-addons/ ${THIRD_PARTY_ADDONS}/
 
 USER odoo
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,25 +42,30 @@ RUN mkdir -p "${THIRD_PARTY_ADDONS}" && chown -R odoo "${THIRD_PARTY_ADDONS}"
 
 USER odoo
 
-COPY canada_mis_report /mnt/extra-addons/canada_mis_report
-COPY canada_vat_label /mnt/extra-addons/canada_vat_label
-COPY konvergo_account /mnt/extra-addons/konvergo_account
-COPY konvergo_account_fr /mnt/extra-addons/konvergo_account_fr
+# Core architecture modules
 COPY konvergo_base /mnt/extra-addons/konvergo_base
-COPY konvergo_bot /mnt/extra-addons/konvergo_bot
-COPY konvergo_brand /mnt/extra-addons/konvergo_brand
 COPY konvergo_core /mnt/extra-addons/konvergo_core
-COPY konvergo_mail_notification /mnt/extra-addons/konvergo_mail_notification
-COPY konvergo_mail_templates /mnt/extra-addons/konvergo_mail_templates
+COPY konvergo_ui /mnt/extra-addons/konvergo_ui
+COPY konvergo_brand /mnt/extra-addons/konvergo_brand
+
+# Functional packs
 COPY konvergo_pack_contact /mnt/extra-addons/konvergo_pack_contact
 COPY konvergo_pack_crm /mnt/extra-addons/konvergo_pack_crm
 COPY konvergo_pack_pos /mnt/extra-addons/konvergo_pack_pos
 COPY konvergo_pack_product /mnt/extra-addons/konvergo_pack_product
 COPY konvergo_pack_sale /mnt/extra-addons/konvergo_pack_sale
-COPY konvergo_ui /mnt/extra-addons/konvergo_ui
-COPY lang_fr_activated /mnt/extra-addons/lang_fr_activated
-COPY mail_color_konvergo /mnt/extra-addons/mail_color_konvergo
-COPY mail_template_fr_fields /mnt/extra-addons/mail_template_fr_fields
+
+# Modules to be migrated later (commented out)
+# COPY canada_mis_report /mnt/extra-addons/canada_mis_report  # -> konvergo_l10n_ca
+# COPY canada_vat_label /mnt/extra-addons/canada_vat_label    # -> konvergo_l10n_ca
+# COPY konvergo_account /mnt/extra-addons/konvergo_account          # TBD
+# COPY konvergo_account_fr /mnt/extra-addons/konvergo_account_fr    # -> konvergo_l10n_fr
+# COPY konvergo_bot /mnt/extra-addons/konvergo_bot                  # -> konvergo_mail_core
+# COPY konvergo_mail_notification /mnt/extra-addons/konvergo_mail_notification  # -> konvergo_mail_core
+# COPY konvergo_mail_templates /mnt/extra-addons/konvergo_mail_templates          # -> konvergo_pack_templates
+# COPY lang_fr_activated /mnt/extra-addons/lang_fr_activated  # -> konvergo_l10n_fr
+# COPY mail_color_konvergo /mnt/extra-addons/mail_color_konvergo  # -> konvergo_mail_core
+# COPY mail_template_fr_fields /mnt/extra-addons/mail_template_fr_fields      # TBD
 
 COPY .docker_files/main /mnt/extra-addons/main
 COPY .docker_files/odoo.conf /etc/odoo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   odoo:
     build:
@@ -18,7 +17,7 @@ services:
     environment:
       - LOG_ODOO=/var/log/odoo
   db:
-    image: postgres:9.6
+    image: postgres:15
     environment:
       - POSTGRES_PASSWORD=odoo
       - POSTGRES_USER=odoo

--- a/gitoo-numigi.yml
+++ b/gitoo-numigi.yml
@@ -1,77 +1,80 @@
-- url: https://github.com/Numigi/odoo-account-addons
-  branch: "14.0"
-  includes:
-    - account_bank_menu
-    - account_closing_journal
-    - account_closing_journal_mis_builder
-    - account_fiscalyear_end_on_company
-    - account_fr_ca_labels
-    - account_invoice_constraint_chronology_forced
-    - account_move_reversal_access
-    - account_move_unique_reversal
-    - account_negative_debit_credit
-    - account_payment_cancel_group
-    - account_payment_widget_link
-    - account_reconciliation_widget
-    - account_show_full_features
-    - account_type_sane
-    - bank_statement_import_csv
-    - canada_account_types
-    - invoice_currency_validation
-    - invoice_refund_not_earlier
-    - old_accounts
+# Numigi addons
+# All v14 dependencies commented out for v18 migration
+# Will be re-enabled progressively as they are migrated to v18
 
-- url: https://github.com/Numigi/aeroo_reports
-  branch: "14.0"
-  includes:
-    - account_check_printing_aeroo
-    - report_aeroo
+# - url: https://github.com/Numigi/odoo-account-addons
+#   branch: "14.0"
+#   includes:
+#     - account_bank_menu
+#     - account_closing_journal
+#     - account_closing_journal_mis_builder
+#     - account_fiscalyear_end_on_company
+#     - account_fr_ca_labels
+#     - account_invoice_constraint_chronology_forced
+#     - account_move_reversal_access
+#     - account_move_unique_reversal
+#     - account_negative_debit_credit
+#     - account_payment_cancel_group
+#     - account_payment_widget_link
+#     - account_reconciliation_widget
+#     - account_show_full_features
+#     - account_type_sane
+#     - bank_statement_import_csv
+#     - canada_account_types
+#     - invoice_currency_validation
+#     - invoice_refund_not_earlier
+#     - old_accounts
 
-- url: https://github.com/Numigi/odoo-base-addons
-  branch: "14.0"
-  includes:
-    - base_extended_security
-    - base_xml_rename
-    - mail_bot_no_pong
-    - mail_notification_no_action_button
-    # - numipack_account
+# - url: https://github.com/Numigi/aeroo_reports
+#   branch: "14.0"
+#   includes:
+#     - account_check_printing_aeroo
+#     - report_aeroo
 
-- url: https://github.com/Numigi/odoo-sale-addons
-  branch: "14.0"
-  includes:
-    - sale_stock_availability_popover
-    - sale_delivery_completion
+# - url: https://github.com/Numigi/odoo-base-addons
+#   branch: "14.0"
+#   includes:
+#     - base_extended_security
+#     - base_xml_rename
+#     - mail_bot_no_pong
+#     - mail_notification_no_action_button
+#     # - numipack_account
 
-- url: https://github.com/Numigi/odoo-partner-addons
-  branch: "14.0"
-  includes:
-    - contacts_config_sale_manager
-    - contacts_config_menu_moved_right
-    - partner_category_type
-    - partner_edit_group
-    - partner_full_text_search
-    - partner_key_date
-    - partner_phone_no_envelope
-    - partner_firstname_before_lastname
+# - url: https://github.com/Numigi/odoo-sale-addons
+#   branch: "14.0"
+#   includes:
+#     - sale_stock_availability_popover
+#     - sale_delivery_completion
 
-- url: https://github.com/Numigi/odoo-web-addons
-  branch: "14.0"
-  includes:
-    - resize_observer_error_catcher
-    - web_custom_label
-    - web_search_date_range
-    - web_search_date_range_account
+# - url: https://github.com/Numigi/odoo-partner-addons
+#   branch: "14.0"
+#   includes:
+#     - contacts_config_sale_manager
+#     - contacts_config_menu_moved_right
+#     - partner_category_type
+#     - partner_edit_group
+#     - partner_full_text_search
+#     - partner_key_date
+#     - partner_phone_no_envelope
+#     - partner_firstname_before_lastname
 
+# - url: https://github.com/Numigi/odoo-web-addons
+#   branch: "14.0"
+#   includes:
+#     - resize_observer_error_catcher
+#     - web_custom_label
+#     - web_search_date_range
+#     - web_search_date_range_account
 
-- url: https://github.com/Numigi/odoo-product-addons
-  branch: "14.0"
-  includes:
-    - product_dimension
-    - product_extra_views
-    - product_manufacturer_quick_search
-    - product_variant_button_complete_form 
+# - url: https://github.com/Numigi/odoo-product-addons
+#   branch: "14.0"
+#   includes:
+#     - product_dimension
+#     - product_extra_views
+#     - product_manufacturer_quick_search
+#     - product_variant_button_complete_form
 
-- url: https://{{GIT_TOKEN}}@github.com/Numigi/odoo-theme-backend-community
-  branch: "14.0"
-  includes:
-    - muk_web_theme
+# - url: https://{{GIT_TOKEN}}@github.com/Numigi/odoo-theme-backend-community
+#   branch: "14.0"
+#   includes:
+#     - muk_web_theme

--- a/gitoo-oca.yml
+++ b/gitoo-oca.yml
@@ -1,172 +1,175 @@
 # OCA addons
-- url: https://github.com/OCA/account-financial-reporting
-  branch: "14.0"
-  includes:
-    - account_financial_report
-    - account_tax_balance
-    - mis_builder_cash_flow
-    - partner_statement
+# All v14 dependencies commented out for v18 migration
+# Will be re-enabled progressively as they are migrated to v18
 
-- url: https://github.com/OCA/account-financial-tools
-  branch: "14.0"
-  includes:
-    - account_lock_date_update
-    - account_move_name_sequence
-    - account_invoice_constraint_chronology
+# - url: https://github.com/OCA/account-financial-reporting
+#   branch: "14.0"
+#   includes:
+#     - account_financial_report
+#     - account_tax_balance
+#     - mis_builder_cash_flow
+#     - partner_statement
 
-- url: https://github.com/OCA/account-invoicing
-  branch: "14.0"
-  includes:
-    - account_invoice_constraint_chronology
+# - url: https://github.com/OCA/account-financial-tools
+#   branch: "14.0"
+#   includes:
+#     - account_lock_date_update
+#     - account_move_name_sequence
+#     - account_invoice_constraint_chronology
 
-- url: https://github.com/OCA/account-reconcile
-  branch: "14.0"
-  includes:
-    - account_reconciliation_widget
+# - url: https://github.com/OCA/account-invoicing
+#   branch: "14.0"
+#   includes:
+#     - account_invoice_constraint_chronology
 
-- url: https://github.com/OCA/bank-payment
-  branch: "14.0"
-  includes:
-    - account_payment_mode
-    - account_payment_partner
+# - url: https://github.com/OCA/account-reconcile
+#   branch: "14.0"
+#   includes:
+#     - account_reconciliation_widget
 
-- url: https://github.com/OCA/pos
-  branch: "14.0"
-  includes:
-    - pos_edit_order_line
-    - pos_order_remove_line
-    - pos_order_product_search
-    - pos_product_sort
-    - pos_show_clock
-    - pos_show_config_name
-    - pos_supplierinfo_search
-    - pos_warning_exiting
-    - pos_payment_change
-    - pos_order_mgmt
-    - pos_order_return
-    - pos_receipt_hide_price
-    - pos_require_product_quantity
-    - pos_partner_birthdate
-    - pos_report_discount
-    - pos_timeout
-    - pos_empty_home
-    - pos_access_right
+# - url: https://github.com/OCA/bank-payment
+#   branch: "14.0"
+#   includes:
+#     - account_payment_mode
+#     - account_payment_partner
 
-- url: https://github.com/OCA/bank-statement-import
-  branch: "14.0"
-  includes:
-    - account_statement_import
-    - account_statement_import_base
-    - bank_statement_import_csv
+# - url: https://github.com/OCA/pos
+#   branch: "14.0"
+#   includes:
+#     - pos_edit_order_line
+#     - pos_order_remove_line
+#     - pos_order_product_search
+#     - pos_product_sort
+#     - pos_show_clock
+#     - pos_show_config_name
+#     - pos_supplierinfo_search
+#     - pos_warning_exiting
+#     - pos_payment_change
+#     - pos_order_mgmt
+#     - pos_order_return
+#     - pos_receipt_hide_price
+#     - pos_require_product_quantity
+#     - pos_partner_birthdate
+#     - pos_report_discount
+#     - pos_timeout
+#     - pos_empty_home
+#     - pos_access_right
 
-- url: https://github.com/OCA/crm
-  branch: "14.0"
-  includes:
-    - crm_industry
-    - crm_lead_search_archive
-    - crm_security_group
+# - url: https://github.com/OCA/bank-statement-import
+#   branch: "14.0"
+#   includes:
+#     - account_statement_import
+#     - account_statement_import_base
+#     - bank_statement_import_csv
 
-- url: https://github.com/OCA/community-data-files
-  branch: "14.0"
-  includes:
-    - account_payment_unece
-    - account_tax_unece
-    - base_unece
-    - uom_unece
+# - url: https://github.com/OCA/crm
+#   branch: "14.0"
+#   includes:
+#     - crm_industry
+#     - crm_lead_search_archive
+#     - crm_security_group
 
-- url: https://github.com/OCA/edi
-  branch: "14.0"
-  includes:
-    - account_einvoice_generate
-    - account_invoice_facturx
-    - base_facturx
+# - url: https://github.com/OCA/community-data-files
+#   branch: "14.0"
+#   includes:
+#     - account_payment_unece
+#     - account_tax_unece
+#     - base_unece
+#     - uom_unece
 
-- url: https://github.com/OCA/intrastat-extrastat
-  branch: "14.0"
-  includes:
-    - intrastat_base
+# - url: https://github.com/OCA/edi
+#   branch: "14.0"
+#   includes:
+#     - account_einvoice_generate
+#     - account_invoice_facturx
+#     - base_facturx
 
-- url: https://github.com/OCA/l10n-france
-  branch: "14.0"
-  includes:
-    - l10n_fr_account_invoice_facturx
-    - l10n_fr_account_tax_unece
-    - l10n_fr_account_vat_return
-    - l10n_fr_department
-    - l10n_fr_department_delivery
-    - l10n_fr_fec_oca
-    - l10n_fr_mis_reports
-    - l10n_fr_oca
-    - l10n_fr_siret
-    - l10n_fr_state
+# - url: https://github.com/OCA/intrastat-extrastat
+#   branch: "14.0"
+#   includes:
+#     - intrastat_base
 
-- url: https://github.com/OCA/mis-builder
-  branch: "14.0"
-  includes:
-    - mis_builder
-    - mis_builder_cash_flow
+# - url: https://github.com/OCA/l10n-france
+#   branch: "14.0"
+#   includes:
+#     - l10n_fr_account_invoice_facturx
+#     - l10n_fr_account_tax_unece
+#     - l10n_fr_account_vat_return
+#     - l10n_fr_department
+#     - l10n_fr_department_delivery
+#     - l10n_fr_fec_oca
+#     - l10n_fr_mis_reports
+#     - l10n_fr_oca
+#     - l10n_fr_siret
+#     - l10n_fr_state
 
-- url: https://github.com/OCA/partner-contact
-  branch: "14.0"
-  includes:
-    - partner_contact_birthdate
-    - partner_contact_personal_information_page
-    - partner_email_duplicate_warn
-    - partner_firstname
-    - partner_identification
-    - partner_industry_secondary
+# - url: https://github.com/OCA/mis-builder
+#   branch: "14.0"
+#   includes:
+#     - mis_builder
+#     - mis_builder_cash_flow
 
-- url: https://github.com/OCA/product-attribute
-  branch: "14.0"
-  includes:
-    - product_category_active
-    - product_category_type
-    - product_manufacturer
-    - product_restricted_type
+# - url: https://github.com/OCA/partner-contact
+#   branch: "14.0"
+#   includes:
+#     - partner_contact_birthdate
+#     - partner_contact_personal_information_page
+#     - partner_email_duplicate_warn
+#     - partner_firstname
+#     - partner_identification
+#     - partner_industry_secondary
 
-- url: https://github.com/OCA/reporting-engine
-  branch: "14.0"
-  includes:
-    - report_xlsx
-    - report_xlsx_helper
+# - url: https://github.com/OCA/product-attribute
+#   branch: "14.0"
+#   includes:
+#     - product_category_active
+#     - product_category_type
+#     - product_manufacturer
+#     - product_restricted_type
 
-- url: https://github.com/OCA/sale-workflow
-  branch: "14.0"
-  includes:
-    - product_form_sale_link
-    - sale_cancel_reason
-    - sale_force_invoiced
-    - sale_invoice_policy
-    - sale_order_price_recalculation
-    - sale_order_revision
-    # - sale_stock_cancel_restriction
+# - url: https://github.com/OCA/reporting-engine
+#   branch: "14.0"
+#   includes:
+#     - report_xlsx
+#     - report_xlsx_helper
 
-- url: https://github.com/OCA/server-brand
-  branch: "14.0"
-  includes:
-    - disable_odoo_online
-    - remove_odoo_enterprise
+# - url: https://github.com/OCA/sale-workflow
+#   branch: "14.0"
+#   includes:
+#     - product_form_sale_link
+#     - sale_cancel_reason
+#     - sale_force_invoiced
+#     - sale_invoice_policy
+#     - sale_order_price_recalculation
+#     - sale_order_revision
+#     # - sale_stock_cancel_restriction
 
-- url: https://github.com/OCA/server-tools
-  branch: "14.0"
-  includes:
-    - base_search_fuzzy
-    - onchange_helper
-    - tracking_manager
+# - url: https://github.com/OCA/server-brand
+#   branch: "14.0"
+#   includes:
+#     - disable_odoo_online
+#     - remove_odoo_enterprise
 
-- url: https://github.com/OCA/server-ux
-  branch: "14.0"
-  includes:
-    - base_revision
-    - date_range
-    - date_range_account
+# - url: https://github.com/OCA/server-tools
+#   branch: "14.0"
+#   includes:
+#     - base_search_fuzzy
+#     - onchange_helper
+#     - tracking_manager
 
-- url: https://github.com/OCA/web
-  branch: "14.0"
-  includes:
-    - web_edit_user_filter
+# - url: https://github.com/OCA/server-ux
+#   branch: "14.0"
+#   includes:
+#     - base_revision
+#     - date_range
+#     - date_range_account
 
-- url: https://github.com/OCA/stock-logistics-workflow
-  branch: "14.0"
-  includes:
-    - sale_line_returned_qty
+# - url: https://github.com/OCA/web
+#   branch: "14.0"
+#   includes:
+#     - web_edit_user_filter
+
+# - url: https://github.com/OCA/stock-logistics-workflow
+#   branch: "14.0"
+#   includes:
+#     - sale_line_returned_qty

--- a/konvergo_core/tests/__init__.py
+++ b/konvergo_core/tests/__init__.py
@@ -1,0 +1,4 @@
+# © 2025 Numigi (tm) and all its contributors (https://numigi.com)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from . import test_module

--- a/konvergo_core/tests/test_module.py
+++ b/konvergo_core/tests/test_module.py
@@ -1,0 +1,14 @@
+# © 2025 Numigi (tm) and all its contributors (https://numigi.com)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestKonvergoCore(TransactionCase):
+    """Test that konvergo_core module is properly installed."""
+
+    def test_module_installed(self):
+        """Test that the konvergo_core module is installed."""
+        module = self.env["ir.module.module"].search([("name", "=", "konvergo_core")])
+        self.assertTrue(module)
+        self.assertEqual(module.state, "installed")


### PR DESCRIPTION
## Summary

Clean up all v14 dependencies to prepare for v18 migration.

**Changes:**
- Comment out all OCA modules in `gitoo-oca.yml`
- Comment out all Numigi modules in `gitoo-numigi.yml`
- Update `Dockerfile` to use 18.latest base image
- Comment out OCA/Numigi build stages in Dockerfile

**Rationale:**
All dependencies will be re-enabled progressively as they are migrated to v18. This ensures a clean starting point for the migration.

## Test plan

- [ ] Docker build succeeds with base v18 image
- [ ] No external dependencies are attempted to be installed
- [ ] Core Konvergo modules can be installed