### PR TITLE
TA#83756 [18.0] Add module_change_auto_install to konvergo_core

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
 # Dockerfile for Konvergo ERP v18
-# OCA and Numigi stages commented out - will be re-enabled progressively during migration
 
-# # Stage 1: Install OCA repositories
-# FROM quay.io/numigi/odoo-public:18.latest as oca-stage
-# LABEL maintainer="contact@numigi.com"
-# USER root
-# ARG GIT_TOKEN
-# RUN mkdir -p /mnt/oca-addons && chown -R odoo /mnt/oca-addons
-# COPY ./gitoo-oca.yml /gitoo-oca.yml
-# RUN gitoo install-all --conf_file /gitoo-oca.yml --destination /mnt/oca-addons
+# Stage 1: Install OCA repositories
+FROM quay.io/numigi/odoo-public:18.latest as oca-stage
+LABEL maintainer="contact@numigi.com"
+USER root
+ARG GIT_TOKEN
+RUN mkdir -p /mnt/oca-addons && chown -R odoo /mnt/oca-addons
+COPY ./gitoo-oca.yml /gitoo-oca.yml
+RUN gitoo install-all --conf_file /gitoo-oca.yml --destination /mnt/oca-addons
 
-# # Stage 2: Install Numigi repositories
+# Stage 2: Install Numigi repositories (commented out for now)
 # FROM quay.io/numigi/odoo-public:18.latest as numigi-stage
 # USER root
 # ARG GIT_TOKEN
@@ -36,8 +35,8 @@ ARG GIT_TOKEN
 ENV THIRD_PARTY_ADDONS /mnt/third-party-addons
 RUN mkdir -p "${THIRD_PARTY_ADDONS}" && chown -R odoo "${THIRD_PARTY_ADDONS}"
 
-# Copy modules from previous stages (commented out for now)
-# COPY --from=oca-stage /mnt/oca-addons/ ${THIRD_PARTY_ADDONS}/
+# Copy modules from previous stages
+COPY --from=oca-stage /mnt/oca-addons/ ${THIRD_PARTY_ADDONS}/
 # COPY --from=numigi-stage /mnt/numigi-addons/ ${THIRD_PARTY_ADDONS}/
 
 USER odoo

--- a/gitoo-oca.yml
+++ b/gitoo-oca.yml
@@ -150,6 +150,11 @@
 #     - disable_odoo_online
 #     - remove_odoo_enterprise
 
+- url: https://github.com/OCA/server-tools
+  branch: "18.0"
+  includes:
+    - module_change_auto_install
+
 # - url: https://github.com/OCA/server-tools
 #   branch: "14.0"
 #   includes:

--- a/konvergo_core/__manifest__.py
+++ b/konvergo_core/__manifest__.py
@@ -12,8 +12,8 @@
     "summary": "Technical foundations and security for Konvergo",
     "depends": [
         "base",
-        # OCA/server-tools - Dépendances techniques à activer
-        # "module_change_auto_install",
+        # OCA/server-tools
+        "module_change_auto_install",
         # "web_session_auto_close",
         # "web_disable_export_group",
         # "base_optional_quick_create",


### PR DESCRIPTION
## Summary

Add `module_change_auto_install` from OCA/server-tools to `konvergo_core`.

**Changes:**
- ✅ Enable OCA build stage in Dockerfile
- ✅ Add `module_change_auto_install` to gitoo-oca.yml (branch 18.0)
- ✅ Add dependency in `konvergo_core/__manifest__.py`

**Module purpose:**
`module_change_auto_install` allows changing the `auto_install` flag of modules, providing better control over module installation behavior in Odoo.

**Reference:**
https://github.com/OCA/server-tools/tree/18.0/module_change_auto_install

## Test plan

- [ ] Docker build succeeds
- [ ] OCA stage builds successfully
- [ ] `module_change_auto_install` is installed
- [ ] `konvergo_core` installs without errors
- [ ] Tests pass